### PR TITLE
Move character encoding to utf16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,13 @@
         }
     ],
     "require": {
-        "php": ">=5.3.1",
+        "php": ">=5.4",
         "symfony/process": "^2.3|^3.0"
     },
     "require-dev": {
         "symfony/console": "^2.3|^3.0",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "ext-iconv": "*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Wesnick/FdfUtility/FdfWriter.php
+++ b/src/Wesnick/FdfUtility/FdfWriter.php
@@ -55,89 +55,15 @@ class FdfWriter
     }
 
     /**
-     * @param string $u
-     *
-     * @return int
-     */
-    public static function uniord($u)
-    {
-        $k = mb_convert_encoding($u, 'UCS-2LE', 'UTF-8');
-        $k1 = ord(substr($k, 0, 1));
-        $k2 = ord(substr($k, 1, 1));
-        return $k2 * 256 + $k1;
-    }
-
-    /**
-     * @param string $str
-     * @param int    $l
-     *
-     * @return array
-     */
-    public static function str_split_unicode($str, $l = 0)
-    {
-        if ($l > 0) {
-            $ret = [];
-            $len = mb_strlen($str, 'UTF-8');
-            for ($i = 0; $i < $len; $i += $l) {
-                $ret[] = mb_substr($str, $i, $l, 'UTF-8');
-            }
-            return $ret;
-        }
-        return preg_split("//u", $str, -1, PREG_SPLIT_NO_EMPTY);
-    }
-
-    /**
      * @param $string
      *
      * @return string
      */
     public static function escapePdfString($string)
     {
-        $escaped = '';
-
-        $chars = self::str_split_unicode($string);
-        foreach ($chars as $char) {
-            switch ($ordinal = ord($char)) {
-                // If open paren, close paren, or backslash, escape character
-                case in_array($ordinal, [0x28, 0x29, 0x5c], true):
-                    // backslash == chr(0x5c)
-                    $escaped .= chr(0x5c).$char;
-                    break;
-                case $ordinal < 32:
-                case $ordinal > 126:
-                    $escaped .= sprintf('\\%03o', self::uniord($char));
-                    break;
-                default:
-                    $escaped .= $char;
-            }
-        }
-
-        return $escaped;
-    }
-
-    /**
-     * @param $string
-     *
-     * @return string
-     */
-    public static function escapePdfName($string)
-    {
-        $escaped = '';
-
-        foreach (str_split($string) as $char) {
-            switch ($ordinal = ord($char)) {
-                // If ascii not between 33 and 126, or a hash mark, use a hex code
-                case $ordinal < 33:
-                case $ordinal > 126:
-                case $ordinal === 23:
-                    $escaped .= sprintf('\\%03o', $ordinal);
-                    break;
-                default:
-                    $escaped .= $char;
-            }
-        }
-
-        return $escaped;
+        $utf16Value = mb_convert_encoding($string,'UTF-16BE', 'UTF-8');
+        $utf16Value = strtr($utf16Value, array('(' => '\\(', ')'=>'\\)'));
+        return $utf16Value;
     }
 
     public function generate()
@@ -185,7 +111,7 @@ class FdfWriter
 
     private function appendKey($key)
     {
-        $this->buffer .= sprintf('<< /T (%s)', $this->escapePdfString($key));
+        $this->buffer .= sprintf('<< /T (%s%s%s)', chr(0xFE), chr(0xFF), self::escapePdfString($key));
     }
 
     private function openKids()
@@ -201,7 +127,7 @@ class FdfWriter
     private function appendValue(PdfField $field)
     {
         $valueFormat = $field->isRichText() ? 'RV' : 'V';
-        $this->buffer .= sprintf('/%s %s %s >>', $valueFormat, $field->getEscapedValue($this), $this->getFieldFlags($field))."\n";
+        $this->buffer .= sprintf('/%s %s %s >>', $valueFormat, $field->getEscapedValue(), $this->getFieldFlags($field))."\n";
     }
 
     private function getFieldFlags(PdfField $field)

--- a/src/Wesnick/FdfUtility/FdfWriter.php
+++ b/src/Wesnick/FdfUtility/FdfWriter.php
@@ -55,12 +55,17 @@ class FdfWriter
     }
 
     /**
+     * Encoding solution ported from php-pdftk.
+     *
+     * @see https://github.com/mikehaertl/php-pdftk/blob/master/src/FdfFile.php#L60
+     *
      * @param $string
      *
      * @return string
      */
     public static function escapePdfString($string)
     {
+        // Create UTF-16BE string encode as ASCII hex
         $utf16Value = mb_convert_encoding($string,'UTF-16BE', 'UTF-8');
         $utf16Value = strtr($utf16Value, array('(' => '\\(', ')'=>'\\)'));
         return $utf16Value;

--- a/src/Wesnick/FdfUtility/Fields/ButtonField.php
+++ b/src/Wesnick/FdfUtility/Fields/ButtonField.php
@@ -11,7 +11,7 @@ class ButtonField extends PdfField
 {
     public function getEscapedValue()
     {
-        return '('.FdfWriter::escapePdfName($this->value).')';
+        return '('.FdfWriter::escapePdfString($this->value).')';
     }
 
     /**

--- a/src/Wesnick/FdfUtility/Fields/ButtonField.php
+++ b/src/Wesnick/FdfUtility/Fields/ButtonField.php
@@ -11,7 +11,7 @@ class ButtonField extends PdfField
 {
     public function getEscapedValue()
     {
-        return '('.FdfWriter::escapePdfString($this->value).')';
+        return sprintf('(%s%s%s)', chr(0xFE), chr(0xFF), FdfWriter::escapePdfString($this->value));
     }
 
     /**

--- a/src/Wesnick/FdfUtility/Fields/ChoiceField.php
+++ b/src/Wesnick/FdfUtility/Fields/ChoiceField.php
@@ -22,7 +22,7 @@ class ChoiceField extends PdfField
             return '[ '.$out.' ]';
         }
 
-        return '('.FdfWriter::escapePdfString($value).')';
+        return sprintf('(%s%s%s)', chr(0xFE), chr(0xFF), FdfWriter::escapePdfString($value));
     }
 
     /**

--- a/src/Wesnick/FdfUtility/Fields/ChoiceField.php
+++ b/src/Wesnick/FdfUtility/Fields/ChoiceField.php
@@ -16,13 +16,13 @@ class ChoiceField extends PdfField
         if ($this->isMultiSelect() && is_array($value)) {
             $out = '';
             foreach ($value as $val) {
-                $out .= '('.FdfWriter::escapePdfName($val).')';
+                $out .= '('.FdfWriter::escapePdfString($val).')';
             }
 
             return '[ '.$out.' ]';
         }
 
-        return '('.FdfWriter::escapePdfName($value).')';
+        return '('.FdfWriter::escapePdfString($value).')';
     }
 
     /**

--- a/src/Wesnick/FdfUtility/Fields/TextField.php
+++ b/src/Wesnick/FdfUtility/Fields/TextField.php
@@ -34,7 +34,7 @@ class TextField extends PdfField
     {
         $value = null === $this->value ? $this->defaultValue : $this->value;
 
-        return '('.FdfWriter::escapePdfString($value).')';
+        return sprintf('(%s%s%s)', chr(0xFE), chr(0xFF), FdfWriter::escapePdfString($value));
     }
 
     /**

--- a/tests/FdfUtility/FdfWriterTest.php
+++ b/tests/FdfUtility/FdfWriterTest.php
@@ -15,9 +15,13 @@ class FdfWriterTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['abcdef~', 'abcdef~'], // printable characters
-            ['\()', '\\\\\(\)'],  // escaped characters \,(,)
+            ['John Smith', 'John Smith'], // printable characters
+            ['806 – 4815 Eldoràdo Mews', '806 – 4815 Eldoràdo Mews'], // printable characters
+            ['çÇÀàÈèùÉéâÂÊêÎîÔôÛûëïöüÿæ', 'çÇÀàÈèùÉéâÂÊêÎîÔôÛûëïöüÿæ'], // printable characters
+            ['4045 €', '4045 €'], // printable characters
+            ['\()', '\\\\⠀尩'],  // escaped characters \,(,)
             ['xx xx', 'xx xx'],  // space print normally
-            ['xx'.chr(10).'xx', 'xx\012xx'],  // non-printable characters
+            ['xx'.chr(10).'xx', 'xx'.chr(10).'xx'],  // non-printable characters
         ];
     }
 
@@ -29,16 +33,16 @@ class FdfWriterTest extends \PHPUnit_Framework_TestCase
      */
     public function testEscapePdfString($input, $escaped)
     {
-        $this->assertSame($escaped, FdfWriter::escapePdfString($input));
+        $this->assertSame(iconv('UTF-8', 'UTF-16BE', $escaped), FdfWriter::escapePdfString($input));
     }
 
     public function pdfNames()
     {
         return [
             ['abcdef~', 'abcdef~'], // printable characters
-            ['\()', '\()'],  //  \,(,) are not escaped
-            ['xx xx', 'xx\040xx'],  // space print normally
-            ['xx'.chr(10).'xx', 'xx\012xx'],  // non-printable characters
+            ['\()', '\\\\⠀尩'],  //  \,(,) are not escaped
+            ['xx xx', 'xx xx'],  // space print normally
+            ['xx'.chr(10).'xx', 'xx'.chr(10).'xx'],  // non-printable characters
         ];
     }
 
@@ -50,7 +54,7 @@ class FdfWriterTest extends \PHPUnit_Framework_TestCase
      */
     public function testEscapePdfNames($input, $escaped)
     {
-        $this->assertSame($escaped, FdfWriter::escapePdfName($input));
+        $this->assertSame(iconv('UTF-8', 'UTF-16BE', $escaped), FdfWriter::escapePdfString($input));
     }
 
     public function testAddFields()

--- a/tests/FdfUtility/Fields/ChoiceFieldTest.php
+++ b/tests/FdfUtility/Fields/ChoiceFieldTest.php
@@ -65,12 +65,12 @@ class ChoiceFieldTest extends PdfFieldTest
     {
         $field = new ChoiceField('default_value', 0, 'default', ['default' => 'default', 'default1' => 'default1'], null);
 
-        $this->assertSame(iconv('UTF-8', 'UTF-16BE', '⠀搀攀昀愀甀氀琩'), $field->getEscapedValue(), 'Default Value is respected on null value');
+        $this->assertSame(iconv('UTF-8', 'UTF-16BE', '⣾＀搀攀昀愀甀氀琩'), $field->getEscapedValue(), 'Default Value is respected on null value');
 
         $field->setValue('default1');
-        $this->assertSame(iconv('UTF-8', 'UTF-16BE', '⠀搀攀昀愀甀氀琀ㄩ'), $field->getEscapedValue(), 'Default Value is ignored if value not null');
+        $this->assertSame(iconv('UTF-8', 'UTF-16BE', '⣾＀搀攀昀愀甀氀琀ㄩ'), $field->getEscapedValue(), 'Default Value is ignored if value not null');
 
         $field->setValue('');
-        $this->assertSame(iconv('UTF-8', 'UTF-16BE', '⠩'), $field->getEscapedValue(), 'Default Value is ignored if value is empty');
+        $this->assertSame(iconv('UTF-8', 'UTF-16BE', '⣾Ｉ'), $field->getEscapedValue(), 'Default Value is ignored if value is empty');
     }
 }

--- a/tests/FdfUtility/Fields/ChoiceFieldTest.php
+++ b/tests/FdfUtility/Fields/ChoiceFieldTest.php
@@ -65,12 +65,12 @@ class ChoiceFieldTest extends PdfFieldTest
     {
         $field = new ChoiceField('default_value', 0, 'default', ['default' => 'default', 'default1' => 'default1'], null);
 
-        $this->assertSame('(default)', $field->getEscapedValue(), 'Default Value is respected on null value');
+        $this->assertSame(iconv('UTF-8', 'UTF-16BE', '⠀搀攀昀愀甀氀琩'), $field->getEscapedValue(), 'Default Value is respected on null value');
 
         $field->setValue('default1');
-        $this->assertSame('(default1)', $field->getEscapedValue(), 'Default Value is ignored if value not null');
+        $this->assertSame(iconv('UTF-8', 'UTF-16BE', '⠀搀攀昀愀甀氀琀ㄩ'), $field->getEscapedValue(), 'Default Value is ignored if value not null');
 
         $field->setValue('');
-        $this->assertSame('(\000)', $field->getEscapedValue(), 'Default Value is ignored if value is empty');
+        $this->assertSame(iconv('UTF-8', 'UTF-16BE', '⠩'), $field->getEscapedValue(), 'Default Value is ignored if value is empty');
     }
 }

--- a/tests/FdfUtility/Fields/TextFieldTest.php
+++ b/tests/FdfUtility/Fields/TextFieldTest.php
@@ -78,12 +78,12 @@ class TextFieldTest extends PdfFieldTest
     {
         $field = new TextField('default_value', 0, 'default', [], null);
 
-        $this->assertSame('(default)', $field->getEscapedValue(), 'Default Value is respected on null value');
+        $this->assertSame(iconv('UTF-8', 'UTF-16BE', '⣾＀搀攀昀愀甀氀琩'), $field->getEscapedValue(), 'Default Value is respected on null value');
 
         $field->setValue('value');
-        $this->assertSame('(value)', $field->getEscapedValue(), 'Default Value is ignored if value not null');
+        $this->assertSame(iconv('UTF-8', 'UTF-16BE', '⣾＀瘀愀氀甀攩'), $field->getEscapedValue(), 'Default Value is ignored if value not null');
 
         $field->setValue('');
-        $this->assertSame('()', $field->getEscapedValue(), 'Default Value is ignored if value is empty');
+        $this->assertSame(iconv('UTF-8', 'UTF-16BE', '⣾Ｉ'), $field->getEscapedValue(), 'Default Value is ignored if value is empty');
     }
 }

--- a/tests/FdfUtility/Parser/PdftkDumpParserTest.php
+++ b/tests/FdfUtility/Parser/PdftkDumpParserTest.php
@@ -2,6 +2,7 @@
 
 namespace Wesnick\Tests\FdfUtility\Parser;
 
+use Wesnick\FdfUtility\FdfWriter;
 use Wesnick\FdfUtility\Fields\PdfField;
 use Wesnick\FdfUtility\Parser\PdftkDumpParser;
 
@@ -86,12 +87,12 @@ class PdftkDumpParserTest extends \PHPUnit_Framework_TestCase
     public function valueProvider()
     {
         return [
-            [8, '(read_only)'],
-            [12, '(default_value)'],
-            [24, '(Yes)'],
-            [25, '(Yes)'],
-            [26, '(Tom)'],
-            [27, '(Marco)'],
+            [8, '⣾＀爀攀愀搀开漀渀氀礩'], // (read_only)
+            [12, '⣾＀搀攀昀愀甀氀琀开瘀愀氀甀攩'], // (default_value)
+            [24, '⠀夀攀猩'], // (Yes)
+            [25, '⠀夀攀猩'], // (Yes)
+            [26, '⠀吀漀洩'], // (Tom)
+            [27, '⠀䴀愀爀挀漩'], // (Marco)
         ];
     }
 
@@ -103,7 +104,7 @@ class PdftkDumpParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseGetsValue($index, $value)
     {
-        $this->assertSame($value, $this->fields[$index]->getEscapedValue());
+        $this->assertSame(iconv('UTF-8', 'UTF-16BE', $value), $this->fields[$index]->getEscapedValue());
     }
 
     public function defaultValueProvider()

--- a/tests/FdfUtility/Parser/PdftkDumpParserTest.php
+++ b/tests/FdfUtility/Parser/PdftkDumpParserTest.php
@@ -89,10 +89,10 @@ class PdftkDumpParserTest extends \PHPUnit_Framework_TestCase
         return [
             [8, '⣾＀爀攀愀搀开漀渀氀礩'], // (read_only)
             [12, '⣾＀搀攀昀愀甀氀琀开瘀愀氀甀攩'], // (default_value)
-            [24, '⠀夀攀猩'], // (Yes)
-            [25, '⠀夀攀猩'], // (Yes)
-            [26, '⠀吀漀洩'], // (Tom)
-            [27, '⠀䴀愀爀挀漩'], // (Marco)
+            [24, '⣾＀夀攀猩'], // (Yes)
+            [25, '⣾＀夀攀猩'], // (Yes)
+            [26, '⣾＀吀漀洩'], // (Tom)
+            [27, '⣾＀䴀愀爀挀漩'], // (Marco)
         ];
     }
 


### PR DESCRIPTION
Certain characters (i.e. – (em dash) or € ) were exceeding the supported ones by an octal representation.
Current implementation was not avoiding them but trying to print them giving unexpected behaviors in certain scenarios as printing 806 – 4815 as 806 *23 4815.

Moving to use UTF-16BE instead, allow us to use a bigger set of characters and avoid applying an excesive treatment to the data.

This solution is extracted from php-pdftk library implementation (https://github.com/mikehaertl/php-pdftk/blob/master/src/FdfFile.php)